### PR TITLE
make "result" attribute optional

### DIFF
--- a/cucumber-report-generator/src/main/java/com/github/mkolisnyk/cucumber/reporting/types/result/CucumberStepResult.java
+++ b/cucumber-report-generator/src/main/java/com/github/mkolisnyk/cucumber/reporting/types/result/CucumberStepResult.java
@@ -20,8 +20,10 @@ public class CucumberStepResult {
         this.name = (String) json.get("name");
         this.keyword = (String) json.get("keyword");
         //this.line = (Long) json.get("line");
-        this.result = new CucumberResult(
+         if (json.containsKey("result")) {
+             this.result = new CucumberResult(
                 (JsonObject<String, Object>) json.get("result"));
+         }
         if (json.containsKey("embeddings")) {
             Object[] objs = (Object[]) json.get("embeddings");
             this.embeddings = new CucumberEmbedding[objs.length];


### PR DESCRIPTION
In some use cases, step executions are skipped. e.g. no Step Implementation. 
It'd be better to allow CucumberStepResult without "result" attribute. Otherwise, having "result" mandatory will throw below exception
java.lang.NullPointerException
	at com.github.mkolisnyk.cucumber.reporting.types.result.CucumberResult.<init>(CucumberResult.java:14)
        at com.github.mkolisnyk.cucumber.reporting.types.result.CucumberStepResult.<init>(CucumberStepResult.java:24)