### PR TITLE
#213 Remove itext dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ notifications:
 cache:
   directories:
     - $HOME/.m2
+dist: trusty

--- a/cucumber-report-generator/pom.xml
+++ b/cucumber-report-generator/pom.xml
@@ -8,7 +8,7 @@
 	<artifactId>cucumber-report-generator</artifactId>
 	<name>Cucumber Report Generator</name>
 	<description>
-		The part of the Cucumber Reports library directly responsible for 
+		The part of the Cucumber Reports library directly responsible for
 		reports generation.
 	</description>
 	<packaging>jar</packaging>
@@ -216,7 +216,7 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
-		
+
 	</build>
 	<dependencies>
 		<dependency>
@@ -234,11 +234,6 @@
 					<artifactId>fop</artifactId>
 				</exclusion>
 			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>com.itextpdf</groupId>
-			<artifactId>itextpdf</artifactId>
-			<version>5.5.12</version>
 		</dependency>
 		<dependency>
 			<groupId>com.cedarsoftware</groupId>

--- a/cucumber-runner/build.gradle
+++ b/cucumber-runner/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     compile 'batik:batik-transcoder:1.6-1'
 	compile 'com.cedarsoftware:json-io:4.9.12'
 	compile 'com.github.mkolisnyk:cucumber-report-generator:1.1'
-	compile 'com.itextpdf:itextpdf:5.5.11'
 	compile 'commons-codec:commons-codec:1.10'
 	compile 'info.cukes:cucumber-junit:1.2.5'
 	compile 'info.cukes:cucumber-testng:1.2.5'

--- a/cucumber-runner/pom.xml
+++ b/cucumber-runner/pom.xml
@@ -40,11 +40,6 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>com.itextpdf</groupId>
-			<artifactId>itextpdf</artifactId>
-			<version>5.5.11</version>
-		</dependency>
-		<dependency>
 			<groupId>com.cedarsoftware</groupId>
 			<artifactId>json-io</artifactId>
 			<version>4.9.12</version>


### PR DESCRIPTION
Removed itext dependency because it removes the apache license and it was not used.
Had to fix de distribution to let the build work. A change on travis. 

https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/13